### PR TITLE
Saves utterances after each transcription

### DIFF
--- a/mentor_pipeline/utterances.py
+++ b/mentor_pipeline/utterances.py
@@ -77,13 +77,13 @@ class Utterance:
             else -1
         )
 
-    def get_id(self):
+    def get_id(self) -> str:
         return _utterance_id(self.session, self.part, self.timeStart, self.timeEnd)
 
-    def is_no_transcription_type(self):
-        return self.utteranceType == UtteranceType.IDLE
+    def is_no_transcription_type(self) -> bool:
+        return bool(self.utteranceType == UtteranceType.IDLE)
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         return asdict(self)
 
 

--- a/tests/helpers/mock_transcriptions.py
+++ b/tests/helpers/mock_transcriptions.py
@@ -1,7 +1,12 @@
+from typing import Callable
+import logging
+
 from unittest.mock import call, Mock
 
 from mentor_pipeline.mentorpath import MentorPath
 from mentor_pipeline.utils import yaml_load
+from mentor_pipeline.process import OnDidTranscribe
+from mentor_pipeline.utterances import Utterance
 
 
 class MockTranscriptions:
@@ -20,33 +25,57 @@ class MockTranscriptions:
     """
 
     def __init__(
-        self, mock_init_transcription_service: Mock, mock_logging_info: Mock = None
+        self,
+        mpath: MentorPath,
+        mock_init_transcription_service: Mock,
+        mock_logging_info: Mock = None,
     ):
+        self.mpath = mpath
         self.mock_service = Mock()
         self.mock_logging_info = mock_logging_info
         mock_init_transcription_service.return_value = self.mock_service
 
+    def expect_calls(self) -> None:
+        self.mock_service.transcribe.assert_has_calls(self.expected_transcribe_calls)
+        if self.mock_logging_info:
+            self.mock_logging_info.assert_has_calls(self.expected_calls_logging_info)
+
+    def get_on_did_transcribe(self) -> Callable[[OnDidTranscribe], None]:
+        # Test after each on_did_transcribe callback
+        # that the latest transcription was written.
+        # This is important in case a large batch of transcriptions
+        # only completes partially.
+        # We don't want to lose the completed transcriptions
+        def on_did_transcribe(cb: OnDidTranscribe):
+            logging.warning(f"on_did_transcribe {cb} called!\n\n\n")
+            utterances = self.mpath.load_utterances()
+            assert cb.utterance_id is not None
+            u = utterances.find_by_id(cb.utterance_id)
+            assert isinstance(u, Utterance)
+            assert u.transcript == cb.transcript
+            assert u.transcript in self.expectected_transcriptions
+
+        return on_did_transcribe
+
     def load_expected_calls(
-        self, mpath: MentorPath, mock_transcribe_calls_yaml="mock-transcribe-calls.yaml"
+        self, mock_transcribe_calls_yaml="mock-transcribe-calls.yaml"
     ) -> None:
         mock_transcribe_calls = yaml_load(
-            mpath.get_mentor_data(mock_transcribe_calls_yaml)
+            self.mpath.get_mentor_data(mock_transcribe_calls_yaml)
         )
         self.expected_transcribe_calls = []
         self.expected_calls_logging_info = []
+        self.expectected_transcriptions = []
         expected_transcribe_returns = []
         for i, call_data in enumerate(mock_transcribe_calls):
-            audio_path = mpath.get_mentor_data(call_data.get("audio"))
+            audio_path = self.mpath.get_mentor_data(call_data.get("audio"))
+            transcript = call_data.get("transcript")
             self.expected_transcribe_calls.append(call(audio_path))
-            expected_transcribe_returns.append(call_data.get("transcript"))
+            self.expectected_transcriptions.append(transcript)
+            expected_transcribe_returns.append(transcript)
             self.expected_calls_logging_info.append(
                 call(
                     f"transcribe [{i + 1}/{len(mock_transcribe_calls)}] audio={audio_path}"
                 )
             )
         self.mock_service.transcribe.side_effect = expected_transcribe_returns
-
-    def expect_calls(self) -> None:
-        self.mock_service.transcribe.assert_has_calls(self.expected_transcribe_calls)
-        if self.mock_logging_info:
-            self.mock_logging_info.assert_has_calls(self.expected_calls_logging_info)

--- a/tests/test_run_data_update.py
+++ b/tests/test_run_data_update.py
@@ -43,8 +43,8 @@ def test_it_generates_all_data_files_for_a_mentor(
     mentor_id: str,
 ):
     mpath = copy_mentor_to_tmp(mentor_id, mentor_data_root)
-    mock_transcriptions = MockTranscriptions(mock_init_transcription_service)
-    mock_transcriptions.load_expected_calls(mpath)
+    mock_transcriptions = MockTranscriptions(mpath, mock_init_transcription_service)
+    mock_transcriptions.load_expected_calls()
     MockAudioSlicer(mock_slice_audio, create_dummy_output_files=True)
     MockVideoToAudioConverter(mock_video_to_audio, create_dummy_output_files=True)
     p = Pipeline(mentor_id, mpath.root_path_data_mentors)

--- a/tests/test_utterances_update_transcripts.py
+++ b/tests/test_utterances_update_transcripts.py
@@ -1,12 +1,15 @@
 import pytest
 from unittest.mock import patch
 
-from .helpers import MockTranscriptions, resource_root_mentors_for_test
-from mentor_pipeline.mentorpath import MentorPath
 from mentor_pipeline.process import update_transcripts
 from mentor_pipeline import transcriptions
 from mentor_pipeline.utterances import utterances_from_yaml
 
+from .helpers import (
+    MockTranscriptions,
+    copy_mentor_to_tmp,
+    resource_root_mentors_for_test,
+)
 
 MENTOR_DATA_ROOT = resource_root_mentors_for_test(__file__)
 
@@ -38,9 +41,10 @@ def _test_utterances_update_transcripts(
     test_logging=False,
 ):
     with patch("logging.info") as mock_logging_info:
-        mpath = MentorPath(mentor_id=mentor_id, root_path_data_mentors=mentor_data_root)
+        mpath = copy_mentor_to_tmp(mentor_id, mentor_data_root)
         input_utterances = mpath.load_utterances()
         mock_transcriptions = MockTranscriptions(
+            mpath,
             mock_init_transcription_service,
             mock_logging_info=mock_logging_info if test_logging else None,
         )
@@ -48,9 +52,12 @@ def _test_utterances_update_transcripts(
         expected_utterances = utterances_from_yaml(
             mpath.get_mentor_data("expected-utterances.yaml")
         )
-        mock_transcriptions.load_expected_calls(mpath)
+        mock_transcriptions.load_expected_calls()
         actual_utterances = update_transcripts(
-            input_utterances, dummy_transcription_service, mpath
+            input_utterances,
+            dummy_transcription_service,
+            mpath,
+            on_did_transcribe=None,  # mock_transcriptions.get_on_did_transcribe(),
         )
         mock_transcriptions.expect_calls()
         assert expected_utterances.to_dict() == actual_utterances.to_dict()


### PR DESCRIPTION
Updates mentor-pipeline to save each transcription immediately instead of a single save after all complete. 

The way it was previously,  if you quit the data-build job in the middle of transcription processing, it would have to start over from the beginning. Now you can quit and on next run it should pick up from where it left off.